### PR TITLE
fix: typo in alert messages

### DIFF
--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -18,7 +18,7 @@ javascript: (function () {
         document.getElementsByTagName("head")[0].appendChild(script);
       })
       .catch(function () {
-        alert("Error retreiving PowerDeleteSuite from github");
+        alert("Error retrieving PowerDeleteSuite from github");
       });
   } else if (
     confirm(

--- a/powerdeletesuite.js
+++ b/powerdeletesuite.js
@@ -148,7 +148,7 @@ var pd = {
           $("#pd__central").show();
         },
         function () {
-          alert("Error retreiving CSS from /r/PowerDeleteSuite");
+          alert("Error retrieving CSS from /r/PowerDeleteSuite");
         }
       );
     },
@@ -174,7 +174,7 @@ var pd = {
           pd.helpers.restoreSettings();
         },
         function () {
-          alert("Error retreiving markup from /r/PowerDeleteSuite");
+          alert("Error retrieving markup from /r/PowerDeleteSuite");
         }
       );
     },


### PR DESCRIPTION
Noticed a small typo in one of the `alert` error messages. This PR just changes the spelling of `retreiving` to `retrieving` in all of the `alert` error messages.