### PR TITLE
Added Overview as a source

### DIFF
--- a/powerdeletesuite.js
+++ b/powerdeletesuite.js
@@ -1,5 +1,5 @@
 var pd = {
-  version: "1.4.11",
+  version: "1.4.12",
   bookmarkver: "1.4",
   editStrings: [
     "I love ice cream.",
@@ -307,6 +307,7 @@ var pd = {
         comments: "/user/" + pd.config.user + "/comments/.json",
         submissions: "/user/" + pd.config.user + "/submitted/.json",
         search: "/search.json",
+        overview: "/user/" + pd.config.user + "/overview/.json",
       };
     },
     applyDom: function () {
@@ -454,8 +455,9 @@ var pd = {
                   "comments",
                   "search",
                   "submissions",
+                  "overview",
                 ] /* Search is actually more efficient than submissions if we're not handling submissions (`self:1`) */
-              : ["comments", "submissions", "search"],
+              : ["comments", "submissions", "search","overview"],
           sorts: ["new", "hot", "top", "controversial"],
           timeframes: ["all", "hour", "day", "week", "month", "year"],
         },


### PR DESCRIPTION
There have been changes to /comments where it doesn't show comments over 8 years old, but the overview page still does.

This adds the overview page as a source for comment deletion, and increments the version number. 

This addresses #81 #78 and #67.

For now until this is merged my fork at https://github.com/mcallbosco/PowerDeleteSuite is updated with this patch.